### PR TITLE
Fixed multiple issues with PoshC2.psm1

### DIFF
--- a/resources/scripts/PoshC2.psm1
+++ b/resources/scripts/PoshC2.psm1
@@ -34,11 +34,10 @@ Function Build-PoshC2DockerImage {
         [switch]$NoCache
     )
 
-    Set-Location $PoshC2Dir
     Write-Verbose "[+] Ensure CRLF is replaced by LF"
-    Get-ChildItem -File -Recurse | ForEach-Object { 
+    Get-ChildItem -Path $PoshC2Dir -File -Recurse | ForEach-Object { 
         $Content = Get-Content -Raw -Path $_.FullName
-        $Content -Replace "`r`n","`n" | Set-Content -Path $_.FullName 
+        $Content -Replace "`r`n","`n" | Set-Content -Path $_.FullName -NoNewline -Force
     }
 
     If($NoCache) {

--- a/resources/scripts/PoshC2.psm1
+++ b/resources/scripts/PoshC2.psm1
@@ -1,3 +1,5 @@
+
+
 Function Build-PoshC2DockerImage {
     <#
     .SYNOPSIS
@@ -31,6 +33,13 @@ Function Build-PoshC2DockerImage {
         [string]$PoshC2Dir,
         [switch]$NoCache
     )
+
+    Set-Location $PoshC2Dir
+    Write-Verbose "[+] Ensure CRLF is replaced by LF"
+    Get-ChildItem -File -Recurse | ForEach-Object { 
+        $Content = Get-Content -Raw -Path $_.FullName
+        $Content -Replace "`r`n","`n" | Set-Content -Path $_.FullName 
+    }
 
     If($NoCache) {
         docker build -t nettitude/poshc2 $PoshC2Dir --no-cache

--- a/resources/scripts/PoshC2.psm1
+++ b/resources/scripts/PoshC2.psm1
@@ -35,7 +35,7 @@ Function Build-PoshC2DockerImage {
     )
 
     Write-Verbose "[+] Ensure CRLF is replaced by LF"
-    Get-ChildItem -Path $PoshC2Dir -File -Recurse | ForEach-Object { 
+    Get-ChildItem -Path $PoshC2Dir -File -Recurse | Where-Object {$_.Extension -eq '.sh'} | ForEach-Object { 
         $Content = Get-Content -Raw -Path $_.FullName
         $Content -Replace "`r`n","`n" | Set-Content -Path $_.FullName -NoNewline -Force
     }
@@ -126,7 +126,7 @@ Function Invoke-PoshC2DockerServer {
 
     .EXAMPLE
 
-    Invoke-PoshC2DockerServer -PoshC2Path "C:\PoshC2" -LocalPoshC2ProjectDir "C:\PoshC2_Project" -DockerPoshC2ProjectDir "/opt/PoshC2_Project"
+    Invoke-PoshC2DockerServer -PoshC2Dir "C:\PoshC2" -LocalPoshC2ProjectDir "C:\PoshC2_Project" -DockerPoshC2ProjectDir "/opt/PoshC2_Project"
     #>
     [CmdletBinding()]
     Param(
@@ -134,6 +134,7 @@ Function Invoke-PoshC2DockerServer {
         [string]$PoshC2Dir,
         [Parameter(Mandatory=$true)]
         [string]$LocalPoshC2ProjectDir,
+        [Parameter(Mandatory=$true)]        
         [string]$DockerPoshC2ProjectDir,
         [int]$PoshC2Port = 443
         
@@ -175,7 +176,7 @@ Function Invoke-PoshC2DockerHandler {
 
     .EXAMPLE
 
-    Invoke-PoshC2DockerHandler -PoshC2Path "C:\PoshC2" -PoshC2ProjectDir "C:\PoshC2_Project" -User CrashOverride
+    Invoke-PoshC2DockerHandler -PoshC2Dir "C:\PoshC2" -PoshC2ProjectDir "C:\PoshC2_Project" -User CrashOverride
     #>
     [CmdletBinding()]
     Param(
@@ -183,6 +184,7 @@ Function Invoke-PoshC2DockerHandler {
         [string]$PoshC2Dir,
         [Parameter(Mandatory=$true)]
         [string]$LocalPoshC2ProjectDir,
+        [Parameter(Mandatory=$true)]        
         [string]$DockerPoshC2ProjectDir,
         [string]$User = ""
     )

--- a/resources/scripts/PoshC2.psm1
+++ b/resources/scripts/PoshC2.psm1
@@ -1,83 +1,78 @@
-<#
-.SYNOPSIS
+Function Build-PoshC2DockerImage {
+    <#
+    .SYNOPSIS
 
-Builds the PoshC2 Docker image from the PoshC2 installation at the provided path.
+    Builds the PoshC2 Docker image from the PoshC2 installation at the provided path.
 
-Author: @m0rv4i
-License: BSD 3-Clause
-Required Dependencies: Docker Install
-Optional Dependencies: None
+    Author: @m0rv4i
+    License: BSD 3-Clause
+    Required Dependencies: Docker Install
+    Optional Dependencies: None
 
-.DESCRIPTION
+    .DESCRIPTION
 
-A simple wrapper around the docker build command which specifies the tag name.
+    A simple wrapper around the docker build command which specifies the tag name.
 
-.PARAMETER PoshC2Dir
+    .PARAMETER PoshC2Dir
 
-Specifies the path to the PoshC2 installation which will be built.
+    Specifies the path to the PoshC2 installation which will be built.
 
-.PARAMETER NoCache
+    .PARAMETER NoCache
 
-A switch which specifices that the image should be built without using any cached layers in Docker. 
+    A switch which specifices that the image should be built without using any cached layers in Docker. 
 
-.EXAMPLE
+    .EXAMPLE
 
-Build-PoshC2DockerImage -PoshC2Path C:\PoshC2 -NoCache
-#>
-Function Build-PoshC2DockerImage 
-{
-
+    Build-PoshC2DockerImage -PoshC2Path C:\PoshC2 -NoCache
+    #>
     [CmdletBinding()]
-    params(
+    Param(
         [Parameter(Mandatory=$true)]
         [string]$PoshC2Dir,
         [switch]$NoCache
     )
 
-    if($NoCache)
-    {
+    If($NoCache) {
         docker build -t nettitude/poshc2 $PoshC2Dir --no-cache
-    } else {
+    } Else {
         docker build -t nettitude/poshc2 $PoshC2Dir
     }
 }
 
-<#
-.SYNOPSIS
+Function Clean-PoshC2DockerState {
+    <#
+    .SYNOPSIS
 
-Cleans the Docker cache to free space.
+    Cleans the Docker cache to free space.
 
-Author: @m0rv4i
-License: BSD 3-Clause
-Required Dependencies: Docker Install
-Optional Dependencies: None
+    Author: @m0rv4i
+    License: BSD 3-Clause
+    Required Dependencies: Docker Install
+    Optional Dependencies: None
 
-.DESCRIPTION
+    .DESCRIPTION
 
-A simple wrapper around the Docker system prune command which prints a message and prompts for
-confirmation before cleaning all images & containers in the Docker cache - including none PoshC2 items.
+    A simple wrapper around the Docker system prune command which prints a message and prompts for
+    confirmation before cleaning all images & containers in the Docker cache - including none PoshC2 items.
 
-The Force flag can be added to skip the check.
+    The Force flag can be added to skip the check.
 
-.PARAMETER Force
+    .PARAMETER Force
 
-A switch which skips the confirmation prompt.
+    A switch which skips the confirmation prompt.
 
-.EXAMPLE
+    .EXAMPLE
 
-Clean-PoshC2DockerState 
-#>
-Function Clean-PoshC2DockerState 
-{
-
+    Clean-PoshC2DockerState 
+    #>
     [CmdletBinding()]
-    params(
+    Param(
         [switch]$Force
     )
 
-    if($Force){
+    If($Force){
         docker system prune -f
-        return
+        Return
     }
 
     Write-Output "Do a full docker system prune, cleaning up all unused images & containers?"
@@ -89,41 +84,39 @@ Function Clean-PoshC2DockerState
         docker system prune -f 
     }
 }
-
-<#
-.SYNOPSIS
-
-Runs the PoshC2 C2 Server in Docker.
-
-Author: @m0rv4i
-License: BSD 3-Clause
-Required Dependencies: Docker Install
-Optional Dependencies: None
-
-.DESCRIPTION
-
-Runs the PoshC2 C2 Server in Docker.
-
-.PARAMETER PoshC2Dir
-
-Specifies the path to the PoshC2 installation which will be built.
-
-.PARAMETER PoshC2ProjectDir
-
-The path that is/will be used as the Project Directory for PoshC2.
-
-.PARAMETER PoshC2Port
-
-The Port that the PoshC2 server binds to, defaults to 443.
-
-.EXAMPLE
-
-Invoke-PoshC2DockerServer -PoshC2Path C:\PoshC2 -PoshC2ProjectDir C:\PoshC2_Project
-#>
 Function Invoke-PoshC2DockerServer {
+    <#
+    .SYNOPSIS
 
+    Runs the PoshC2 C2 Server in Docker.
+
+    Author: @m0rv4i
+    License: BSD 3-Clause
+    Required Dependencies: Docker Install
+    Optional Dependencies: None
+
+    .DESCRIPTION
+
+    Runs the PoshC2 C2 Server in Docker.
+
+    .PARAMETER PoshC2Dir
+
+    Specifies the path to the PoshC2 installation which will be built.
+
+    .PARAMETER PoshC2ProjectDir
+
+    The path that is/will be used as the Project Directory for PoshC2.
+
+    .PARAMETER PoshC2Port
+
+    The Port that the PoshC2 server binds to, defaults to 443.
+
+    .EXAMPLE
+
+    Invoke-PoshC2DockerServer -PoshC2Path C:\PoshC2 -PoshC2ProjectDir C:\PoshC2_Project
+    #>
     [CmdletBinding()]
-    params(
+    Param(
         [Parameter(Mandatory=$true)]
         [string]$PoshC2Dir,
         [Parameter(Mandatory=$true)]
@@ -132,43 +125,42 @@ Function Invoke-PoshC2DockerServer {
         
     )
 
-    docker run -ti --rm -p "$PoshC2Port:$PoshC2Port" -v "$PoshC2ProjectDir:$PoshC2ProjectDir" -v "$PoshC2Dir:/opt/PoshC2" nettitude/poshc2 /usr/bin/posh-server
+    docker run -ti --rm -p $("$PoshC2Port" + ":" + "$PoshC2Port") -v $("$PoshC2ProjectDir" + ":" + "$PoshC2ProjectDir") -v $("$PoshC2Dir" + ":" + "/opt/PoshC2") nettitude/poshc2 /usr/bin/posh-server
 }
 
-<#
-.SYNOPSIS
-
-Runs the PoshC2 ImplantHandler in Docker.
-
-Author: @m0rv4i
-License: BSD 3-Clause
-Required Dependencies: Docker Install
-Optional Dependencies: None
-
-.DESCRIPTION
-
-Runs the PoshC2 ImplantHandler in Docker.
-
-.PARAMETER PoshC2Dir
-
-Specifies the path to the PoshC2 installation which will be built.
-
-.PARAMETER PoshC2ProjectDir
-
-The path that is/will be used as the Project Directory for PoshC2.
-
-.PARAMETER User
-
-The user to login as in the ImplantHandler.x
-
-.EXAMPLE
-
-Invoke-PoshC2DockerHandler -PoshC2Path C:\PoshC2 -PoshC2ProjectDir C:\PoshC2_Project -User CrashOverride
-#>
 Function Invoke-PoshC2DockerHandler {
+    <#
+    .SYNOPSIS
 
+    Runs the PoshC2 ImplantHandler in Docker.
+
+    Author: @m0rv4i
+    License: BSD 3-Clause
+    Required Dependencies: Docker Install
+    Optional Dependencies: None
+
+    .DESCRIPTION
+
+    Runs the PoshC2 ImplantHandler in Docker.
+
+    .PARAMETER PoshC2Dir
+
+    Specifies the path to the PoshC2 installation which will be built.
+
+    .PARAMETER PoshC2ProjectDir
+
+    The path that is/will be used as the Project Directory for PoshC2.
+
+    .PARAMETER User
+
+    The user to login as in the ImplantHandler.x
+
+    .EXAMPLE
+
+    Invoke-PoshC2DockerHandler -PoshC2Path C:\PoshC2 -PoshC2ProjectDir C:\PoshC2_Project -User CrashOverride
+    #>
     [CmdletBinding()]
-    params(
+    Param(
         [Parameter(Mandatory=$true)]
         [string]$PoshC2Dir,
         [Parameter(Mandatory=$true)]
@@ -176,39 +168,37 @@ Function Invoke-PoshC2DockerHandler {
         [string]$User = ""
     )
 
-    docker run -ti --rm -v "$PoshC2ProjectDir:$PoshC2ProjectDir" -v "$PoshC2Dir:/opt/PoshC2" nettitude/poshc2 /usr/bin/posh -u "$User"
+    docker run -ti --rm -v $("$PoshC2ProjectDir" + ":" + "$PoshC2ProjectDir") -v $("$PoshC2Dir" + ":" + "/opt/PoshC2") nettitude/poshc2 /usr/bin/posh -u "$User"
 }
 
-<#
-.SYNOPSIS
-
-Updates the PoshC2 installation.
-
-Author: @m0rv4i
-License: BSD 3-Clause
-Required Dependencies: None
-Optional Dependencies: None
-
-.DESCRIPTION
-
-Updates the PoshC2 installation.
-
-.PARAMETER PoshC2Dir
-
-Specifies the path to the PoshC2 installation which will be built.
-
-.EXAMPLE
-
-Update-PoshC2 -PoshC2Dir C:\PoshC2
-#>
 Function Update-PoshC2 {
+    <#
+    .SYNOPSIS
 
+    Updates the PoshC2 installation.
+
+    Author: @m0rv4i
+    License: BSD 3-Clause
+    Required Dependencies: None
+    Optional Dependencies: None
+
+    .DESCRIPTION
+
+    Updates the PoshC2 installation.
+
+    .PARAMETER PoshC2Dir
+
+    Specifies the path to the PoshC2 installation which will be built.
+
+    .EXAMPLE
+
+    Update-PoshC2 -PoshC2Dir C:\PoshC2
+    #>
     [CmdletBinding()]
-    params(
+    Param(
         [Parameter(Mandatory=$true)]
         [string]$PoshC2Dir
     )
-    
     
     Write-Output  """
        __________            .__.     _________  ________
@@ -243,12 +233,10 @@ Function Update-PoshC2 {
     Write-Output "[+] Re-applying Config file changes"
     git apply $env:Temp\PoshC2_Config_Diff.git
 
-    if($?)
-    {
+    If($?) {
         Remote-Item $env:Temp\PoshC2_Config_Diff.git
     } 
-    else
-    {
+    Else {
         Write-Output "[-] Re-applying Config file changes failed, please merge manually from /tmp/PoshC2_Config_Diff.git"
     } 
 
@@ -259,7 +247,7 @@ Function Update-PoshC2 {
     Write-Output ""
 }
 
-Export-ModuleMember -Function Build-PoshC2DockerImage -Alias posh-docker-build,
+Export-ModuleMember -Function Build-PoshC2DockerImage -Alias posh-docker-build
 Export-ModuleMember -Function Clean-PoshC2DockerState -Alias posh-docker-clean
 Export-ModuleMember -Function Invoke-PoshC2DockerServer -Alias posh-docker-server
 Export-ModuleMember -Function Invoke-PoshC2DockerHandler -Alias posh-docker

--- a/resources/scripts/PoshC2.psm1
+++ b/resources/scripts/PoshC2.psm1
@@ -30,8 +30,8 @@ Function Build-PoshC2DockerImage
     [CmdletBinding()]
     params(
         [Parameter(Mandatory=$true)]
-        [string] PoshC2Dir,
-        [switch] NoCache
+        [string]$PoshC2Dir,
+        [switch]$NoCache
     )
 
     if($NoCache)
@@ -72,7 +72,7 @@ Function Clean-PoshC2DockerState
 
     [CmdletBinding()]
     params(
-        [switch] Force
+        [switch]$Force
     )
 
     if($Force){
@@ -125,10 +125,10 @@ Function Invoke-PoshC2DockerServer {
     [CmdletBinding()]
     params(
         [Parameter(Mandatory=$true)]
-        [string] PoshC2Dir,
+        [string]$PoshC2Dir,
         [Parameter(Mandatory=$true)]
-        [string] PoshC2ProjectDir,
-        [int] PoshC2Port = 443
+        [string]$PoshC2ProjectDir,
+        [int]$PoshC2Port = 443
         
     )
 
@@ -170,10 +170,10 @@ Function Invoke-PoshC2DockerHandler {
     [CmdletBinding()]
     params(
         [Parameter(Mandatory=$true)]
-        [string] PoshC2Dir,
+        [string]$PoshC2Dir,
         [Parameter(Mandatory=$true)]
-        [string] PoshC2ProjectDir,
-        [string] User = ""
+        [string]$PoshC2ProjectDir,
+        [string]$User = ""
     )
 
     docker run -ti --rm -v "$PoshC2ProjectDir:$PoshC2ProjectDir" -v "$PoshC2Dir:/opt/PoshC2" nettitude/poshc2 /usr/bin/posh -u "$User"
@@ -206,7 +206,7 @@ Function Update-PoshC2 {
     [CmdletBinding()]
     params(
         [Parameter(Mandatory=$true)]
-        [string] PoshC2Dir
+        [string]$PoshC2Dir
     )
     
     

--- a/resources/scripts/PoshC2.psm1
+++ b/resources/scripts/PoshC2.psm1
@@ -34,7 +34,7 @@ Function Build-PoshC2DockerImage {
         [switch]$NoCache
     )
 
-    Write-Verbose "[+] Ensure CRLF is replaced by LF"
+    Write-Verbose "[+] Ensure .sh files use LF instead of CRLF"
     Get-ChildItem -Path $PoshC2Dir -File -Recurse | Where-Object {$_.Extension -eq '.sh'} | ForEach-Object { 
         $Content = Get-Content -Raw -Path $_.FullName
         $Content -Replace "`r`n","`n" | Set-Content -Path $_.FullName -NoNewline -Force

--- a/resources/scripts/PoshC2.psm1
+++ b/resources/scripts/PoshC2.psm1
@@ -200,6 +200,8 @@ Function Update-PoshC2 {
         [string]$PoshC2Dir
     )
     
+    $DiffFile = Join-Path $(Join-Path $env:Temp $(((New-Guid).guid).split("-")[0])) PoshC2_Config_Diff.git
+
     Write-Output  """
        __________            .__.     _________  ________
        \_______  \____  _____|  |__   \_   ___ \ \_____  \\
@@ -214,11 +216,11 @@ Function Update-PoshC2 {
     Write-Output ""
 
     Push-Location "$PoshC2Dir"
-
+    
     Write-Output ""
     Write-Output "[+] Saving changes to Config.py"
     Write-Output ""
-    git diff Config.py >> $env:Temp\PoshC2_Config_Diff.git
+    git diff Config.py >> $DiffFile
 
     Write-Output ""
     Write-Output "[+] Updating Posh Installation to latest master"
@@ -231,13 +233,13 @@ Function Update-PoshC2 {
 
     Write-Output ""
     Write-Output "[+] Re-applying Config file changes"
-    git apply $env:Temp\PoshC2_Config_Diff.git
+    git apply $DiffFile
 
     If($?) {
-        Remote-Item $env:Temp\PoshC2_Config_Diff.git
+        Remove-Item $DiffFile
     } 
     Else {
-        Write-Output "[-] Re-applying Config file changes failed, please merge manually from /tmp/PoshC2_Config_Diff.git"
+        Write-Output "[-] Re-applying Config file changes failed, please merge manually from $DiffFile"
     } 
 
     Pop-Location

--- a/resources/scripts/PoshC2.psm1
+++ b/resources/scripts/PoshC2.psm1
@@ -189,7 +189,7 @@ Function Invoke-PoshC2DockerHandler {
         [string]$User = ""
     )
 
-    docker run -ti --rm -v -v $("$LocalPoshC2ProjectDir" + ":" + "$DockerPoshC2ProjectDir") -v $("$PoshC2Dir" + ":" + "/opt/PoshC2") nettitude/poshc2 /usr/bin/posh -u "$User"
+    docker run -ti --rm -v $("$LocalPoshC2ProjectDir" + ":" + "$DockerPoshC2ProjectDir") -v $("$PoshC2Dir" + ":" + "/opt/PoshC2") nettitude/poshc2 /usr/bin/posh -u "$User"
 }
 
 Function Update-PoshC2 {

--- a/resources/scripts/PoshC2.psm1
+++ b/resources/scripts/PoshC2.psm1
@@ -25,7 +25,7 @@ Function Build-PoshC2DockerImage {
 
     .EXAMPLE
 
-    Build-PoshC2DockerImage -PoshC2Path C:\PoshC2 -NoCache
+    Build-PoshC2DockerImage -PoshC2Dir C:\PoshC2 -NoCache
     #>
     [CmdletBinding()]
     Param(
@@ -121,7 +121,7 @@ Function Invoke-PoshC2DockerServer {
 
     .EXAMPLE
 
-    Invoke-PoshC2DockerServer -PoshC2Path C:\PoshC2 -PoshC2ProjectDir C:\PoshC2_Project
+    Invoke-PoshC2DockerServer -PoshC2Dir C:\PoshC2 -PoshC2ProjectDir C:\PoshC2_Project
     #>
     [CmdletBinding()]
     Param(
@@ -165,7 +165,7 @@ Function Invoke-PoshC2DockerHandler {
 
     .EXAMPLE
 
-    Invoke-PoshC2DockerHandler -PoshC2Path C:\PoshC2 -PoshC2ProjectDir C:\PoshC2_Project -User CrashOverride
+    Invoke-PoshC2DockerHandler -PoshC2Dir C:\PoshC2 -PoshC2ProjectDir C:\PoshC2_Project -User CrashOverride
     #>
     [CmdletBinding()]
     Param(


### PR DESCRIPTION
Hi, fixed some issues I ran into getting PoshC2 setup on a windows host with the included powershell module.

Running on the 5.2 release, removed `pyttsx3` from the requirments.txt

```powershell
PS C:\Users\justin-p > $PSVersionTable

Name                           Value
----                           -----
PSVersion                      5.1.18362.145
PSEdition                      Desktop
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
BuildVersion                   10.0.18362.145
CLRVersion                     4.0.30319.42000
WSManStackVersion              3.0
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
```

![](https://i.imgur.com/wwQWFz5.png)

1. Param blocks where missing $ at declaration.

```powershell
PS C:\Users\justin-p\Desktop> Function Build-PoshC2DockerImage {
    params(
        [Parameter(Mandatory=$true)]
        [string] PoshC2Dir,
        [switch] NoCache
    )

    if($NoCache) {
        docker build -t nettitude/poshc2 $PoshC2Dir --no-cache
    } else {
        docker build -t nettitude/poshc2 $PoshC2Dir
    }
}
At line:2 char:5
+     [CmdletBinding()]
+     ~~~~~~~~~~~~~~~~~
Unexpected attribute 'CmdletBinding'.
At line:3 char:5
+     params(
+     ~~~~~~
Unexpected token 'params' in expression or statement.
At line:5 char:18
+         [string] PoshC2Dir,
+                  ~~~~~~~~~
Unexpected token 'PoshC2Dir' in expression or statement.
At line:5 char:17
+         [string] PoshC2Dir,
+                 ~
Missing closing ')' in expression.
At line:1 char:34
+ Function Build-PoshC2DockerImage {
+                                  ~
Missing closing '}' in statement block or type definition.
At line:7 char:5
+     )
+     ~
Unexpected token ')' in expression or statement.
At line:14 char:1
+ }
+ ~
Unexpected token '}' in expression or statement.
At line:4 char:9
+         [Parameter(Mandatory=$true)]
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Unexpected attribute 'Parameter'.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : UnexpectedAttribute
```

```powershell
PS C:\Users\justin-p\Desktop> Function Build-PoshC2DockerImage {
    #[CmdletBinding()]
    Params(
        [Parameter(Mandatory=$true)]
        [string]$PoshC2Dir,
        [switch]$NoCache
    )

    if($NoCache) {
        docker build -t nettitude/poshc2 $PoshC2Dir --no-cache
    } else {
        docker build -t nettitude/poshc2 $PoshC2Dir
    }
}

PS C:\Users\justin-p\Desktop> 
```

2. In order to use `[CmdletBinding()]` you need a Param block, not a Params block.

```powershell
Function Build-PoshC2DockerImage {
    [CmdletBinding()]
    Params(
        [Parameter(Mandatory=$true)]
        [string]$PoshC2Dir,
        [switch]$NoCache
    )

    if($NoCache) {
        docker build -t nettitude/poshc2 $PoshC2Dir --no-cache
    } else {
        docker build -t nettitude/poshc2 $PoshC2Dir
    }
}
```

```powershell
Function Build-PoshC2DockerImage {
    [CmdletBinding()]
    Param(
        [Parameter(Mandatory=$true)]
        [string]$PoshC2Dir,
        [switch]$NoCache
    )

    if($NoCache) {
        docker build -t nettitude/poshc2 $PoshC2Dir --no-cache
    } else {
        docker build -t nettitude/poshc2 $PoshC2Dir
    }
}
```

3. `:` needs to be escaped. [This has most likely something todo with the way variable scopes work.](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_scopes?view=powershell-7)

```powershell
PS C:\Users\justin-p\Desktop> $a = 'a'

PS C:\Users\justin-p\Desktop> $a:aaaaa

PS C:\Users\justin-p\Desktop> $a
a
```

```powershell
PS C:\Users\justin-p\Desktop> Import-Module .\poshc2.psm1
At C:\Users\justin-p\Desktop\poshc2.psm1:128 char:29
+     docker run -ti --rm -p "$PoshC2Port:$PoshC2Port" -v "$PoshC2Proje ...
+                             ~~~~~~~~~~~~
Variable reference is not valid. ':' was not followed by a valid variable name character. Consider using ${} to delimit the name.
At C:\Users\justin-p\Desktop\poshc2.psm1:128 char:58
+ ...  -ti --rm -p "$PoshC2Port:$PoshC2Port" -v "$PoshC2ProjectDir:$PoshC2P ...
+                                                ~~~~~~~~~~~~~~~~~~
Variable reference is not valid. ':' was not followed by a valid variable name character. Consider using ${} to delimit the name.
At C:\Users\justin-p\Desktop\poshc2.psm1:128 char:99
+ ... ort" -v "$PoshC2ProjectDir:$PoshC2ProjectDir" -v "$PoshC2Dir:/opt/Pos ...
+                                                       ~~~~~~~~~~~
Variable reference is not valid. ':' was not followed by a valid variable name character. Consider using ${} to delimit the name.
At C:\Users\justin-p\Desktop\poshc2.psm1:171 char:29
+     docker run -ti --rm -v "$PoshC2ProjectDir:$PoshC2ProjectDir" -v " ...
+                             ~~~~~~~~~~~~~~~~~~
Variable reference is not valid. ':' was not followed by a valid variable name character. Consider using ${} to delimit the name.
At C:\Users\justin-p\Desktop\poshc2.psm1:171 char:70
+ ... --rm -v "$PoshC2ProjectDir:$PoshC2ProjectDir" -v "$PoshC2Dir:/opt/Pos ...
+                                                       ~~~~~~~~~~~
Variable reference is not valid. ':' was not followed by a valid variable name character. Consider using ${} to delimit the name.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : InvalidVariableReferenceWithDrive
```

This can be done like this

```powershell
"$PoshC2ProjectDir`:$PoshC2ProjectDir"

PS C:\Users\justin-p\Desktop> $PoshC2Port = 443

PS C:\Users\justin-p\Desktop> "$PoshC2Port`:$PoshC2Port"
443:443

```

But personally I prefer doing this for readability

```powershell
$("$PoshC2Port" + ":" + "$PoshC2Port")

PS C:\Users\justin-p\Desktop> $PoshC2Port = 443

PS C:\Users\justin-p\Desktop> $("$PoshC2Port" + ":" + "$PoshC2Port")
443:443
```

4. Comment Based Help should be inside of the function. This way it works with commands such as Get-Help etc.

```powershell
PS C:\Users\justin-p\Desktop> Function Clean-PoshC2DockerState {
    params(
        [switch]$Force
    )

    if($Force){
        docker system prune -f
        return
    }

    Write-Output "Do a full docker system prune, cleaning up all unused images & containers?"
    Write-Output "*** This includes anything none-PoshC2 related. ***"

    $confirmation = Read-Host "Would you like to do a clean? y/N"

    if ($confirmation -eq 'y' -or $confirmation -eq 'Y') {
        docker system prune -f 
    }
}

PS C:\Users\justin-p\Desktop> get-help Clean-PoshC2DockerState

NAME
    Clean-PoshC2DockerState
    
SYNTAX
    Clean-PoshC2DockerState  
    

ALIASES
    None
    

REMARKS
    None




PS C:\Users\justin-p\Desktop> get-help Clean-PoshC2DockerState -full

NAME
    Clean-PoshC2DockerState
    
SYNTAX
    Clean-PoshC2DockerState  
    
    
PARAMETERS
    None
    
    
INPUTS
    None
    
    
OUTPUTS
    System.Object
    
ALIASES
    None
    

REMARKS
    None
```


```powershell
PS C:\Users\justin-p\Desktop> Function Clean-PoshC2DockerState {
    <#
    .SYNOPSIS
    
    Cleans the Docker cache to free space.
    
    Author: @m0rv4i
    License: BSD 3-Clause
    Required Dependencies: Docker Install
    Optional Dependencies: None
    
    .DESCRIPTION
    
    A simple wrapper around the Docker system prune command which prints a message and prompts for
    confirmation before cleaning all images & containers in the Docker cache - including none PoshC2 items.
    
    The Force flag can be added to skip the check.
    
    .PARAMETER Force
    
    A switch which skips the confirmation prompt.
    
    .EXAMPLE
    
    Clean-PoshC2DockerState 
    #>
    params(
        [switch]$Force
    )

    if($Force){
        docker system prune -f
        return
    }

    Write-Output "Do a full docker system prune, cleaning up all unused images & containers?"
    Write-Output "*** This includes anything none-PoshC2 related. ***"

    $confirmation = Read-Host "Would you like to do a clean? y/N"

    if ($confirmation -eq 'y' -or $confirmation -eq 'Y') {
        docker system prune -f 
    }
}

PS C:\Users\justin-p\Desktop> get-help Clean-PoshC2DockerState -full

NAME
    Clean-PoshC2DockerState
    
SYNOPSIS
    Cleans the Docker cache to free space.
    
    Author: @m0rv4i
    License: BSD 3-Clause
    Required Dependencies: Docker Install
    Optional Dependencies: None
    
    
SYNTAX
    Clean-PoshC2DockerState [<CommonParameters>]
    
    
DESCRIPTION
    A simple wrapper around the Docker system prune command which prints a message and prompts for
    confirmation before cleaning all images & containers in the Docker cache - including none PoshC2 items.
    
    The Force flag can be added to skip the check.
    

PARAMETERS
    <CommonParameters>
        This cmdlet supports the common parameters: Verbose, Debug,
        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
        OutBuffer, PipelineVariable, and OutVariable. For more information, see 
        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216). 
    
INPUTS
    
OUTPUTS
    
    -------------------------- EXAMPLE 1 --------------------------
    
    PS C:\>Clean-PoshC2DockerState
    
    
    
    
    
    
    
RELATED LINKS
```

5. Comma in Export-ModuleMember block breaks the module.

```powershell
Export-ModuleMember -Function Build-PoshC2DockerImage -Alias posh-docker-build, # <---
Export-ModuleMember -Function Clean-PoshC2DockerState -Alias posh-docker-clean
Export-ModuleMember -Function Invoke-PoshC2DockerServer -Alias posh-docker-server
Export-ModuleMember -Function Invoke-PoshC2DockerHandler -Alias posh-docker
Export-ModuleMember -Function Update-PoshC2  -Alias posh-update


PS C:\Users\justin-p\Desktop> Import-Module .\poshc2.psm1
Export-ModuleMember : Cannot bind parameter because parameter 'Function' is specified more than once. To provide multiple values 
to parameters that can accept multiple values, use the array syntax. For example, "-parameter value1,value2,value3".
At C:\Users\justin-p\Desktop\poshc2.psm1:251 char:21
+ Export-ModuleMember -Function Clean-PoshC2DockerState -Alias posh-doc ...
+                     ~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Export-ModuleMember], ParameterBindingException
    + FullyQualifiedErrorId : ParameterAlreadyBound,Microsoft.PowerShell.Commands.ExportModuleMemberCommand
 

Export-ModuleMember -Function Build-PoshC2DockerImage -Alias posh-docker-build
Export-ModuleMember -Function Clean-PoshC2DockerState -Alias posh-docker-clean
Export-ModuleMember -Function Invoke-PoshC2DockerServer -Alias posh-docker-server
Export-ModuleMember -Function Invoke-PoshC2DockerHandler -Alias posh-docker
Export-ModuleMember -Function Update-PoshC2  -Alias posh-update

PS C:\Users\justin-p\Desktop> Import-Module .\poshc2.psm1
PS C:\Users\justin-p\Desktop> get-help Build-PoshC2DockerImage 

NAME
    Build-PoshC2DockerImage
    
SYNTAX
    Build-PoshC2DockerImage [-PoshC2Dir] <string> [-NoCache]  [<CommonParameters>]
    

ALIASES
    None
    

REMARKS
    None
```

6. Fix typo in Update-PoshC2

```powershell
Remote-Item vs Remove-Item
```

7. Ensure Update-PoshC2 creates a new diff file with each run.

```powershell
PS> $DiffFile = Join-Path $(Join-Path $env:Temp $(((New-Guid).guid).split("-")[0])) PoshC2_Config_Diff.git
PS> $DiffFile
C:\Users\justin-p\AppData\Local\Temp\826cba20\PoshC2_Config_Diff.git
```

8. If you don't have git configured to use LF, when cloned to a windows machine, Install.sh breaks due CRLF.

```powershell
Step 4/6 : ADD . /opt/PoshC2
 ---> c070039823ef
Step 5/6 : RUN /opt/PoshC2/Install.sh
 ---> Running in 03622b5fa29e
[91m/bin/sh: 1: /opt/PoshC2/Install.sh: not found
docker : The command '/bin/sh -c /opt/PoshC2/Install.sh' returned a non-zero code: 127
At line:12 char:9
+         docker build -t nettitude/poshc2 $PoshC2Dir
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (The command '/b...-zero code: 127:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
[0m
```

Fixed by adding the code below to the `Build-PoshC2DockerImage` function.

```powershell
Write-Verbose "[+] Ensure .sh files use LF instead of CRLF"
Get-ChildItem -Path $PoshC2Dir -File -Recurse | Where-Object {$_.Extension -eq '.sh'} | ForEach-Object { 
    $Content = Get-Content -Raw -Path $_.FullName
    $Content -Replace "`r`n","`n" | Set-Content -Path $_.FullName -NoNewline -Force
}
```

```powershell
[+] Setup complete

   __________            .__.     _________  ________
   \_______  \____  _____|  |__   \_   ___ \ \_____  \\
    |     ___/  _ \/  ___/  |  \  /    \  \/  /  ____/
    |    |   ( <_>)___  \|   Y  \ \     \____/       \\
    |____|   \____/____  >___|  /  \______  /\_______ \\
                       \/     \/          \/         \/
    ================= www.PoshC2.co.uk ================

Edit the config file - run:
# posh-config

Then run:
# posh-server <-- This will run the C2 server, which communicates with Implants and receives task output
# posh <-- This will run the ImplantHandler, used to issue commands to the server and implants

Other options:
posh-service <-- This will run the C2 server as a service instead of in the foreground
posh-log <-- This will view the C2 log if the server is already running
Removing intermediate container 4327911d7758
 ---> f3cf2eef16b8
Step 6/6 : WORKDIR /opt/PoshC2
 ---> Running in d0764e0a30b8
Removing intermediate container d0764e0a30b8
 ---> 42b2fd7ecde2
Successfully built 42b2fd7ecde2
Successfully tagged nettitude/poshc2:latest
SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.
```

Should probably be fixed by using a `.gitattributes` file instead.

9. `Invoke-PoshC2DockerServer` and `Invoke-PoshC2DockerHandler` can't use `$PoshC2ProjectDir` as linux path

```powershell
PS C:\Users\justin-p > Invoke-PoshC2DockerServer -PoshC2Dir "C:\tools\PoshC2" -PoshC2ProjectDir "C:\PoshC2_Project"
C:\ProgramData\chocolatey\lib\docker-cli\tools\docker.exe: Error response from daemon: Mount denied:
The source path "C:/PoshC2_Project:C"
doesn't exist and is not known to Docker.
See 'C:\ProgramData\chocolatey\lib\docker-cli\tools\docker.exe run --help'.
```

Fixed by replacing the PoshC2ProjectDir Param with `LocalPoshC2ProjectDir` and `DockerPoshC2ProjectDir`.

```powershell
docker run -ti --rm -v -v $("$LocalPoshC2ProjectDir" + ":" + "$DockerPoshC2ProjectDir")
```

```powershell
Invoke-PoshC2DockerServer -PoshC2Dir "C:\Tools\PoshC2" -LocalPoshC2ProjectDir "C:\PoshC2_Project\" -DockerPoshC2ProjectDir "/opt/project"


                    _________            .__.     _________  ________
                    \_______ \____  _____|  |__   \_   ___ \ \_____  \\
                    |     ___/  _ \/  ___/  |  \  /    \  \/  /  ____/
                    |    |  (  <_> )___ \|   Y  \ \     \____/       \\
                    |____|   \____/____  >___|  /  \______  /\_______ \\
                                        \/     \/          \/         \/
          =============== PoshC2 v5.2 (8e47363 2020-01-08 14:02:08) ===============


Initializing new project folder and database

Creating Rewrite Rules in: /opt/PoshC2_Project/rewrite-rules.txt

Raw Payload written to: /opt/PoshC2_Project/payloads/payload.txt
Batch Payload written to: /opt/PoshC2_Project/payloads/payload.bat
C# Dropper Payload written to: /opt/PoshC2_Project/payloads/dropper.cs
C# Dropper DLL written to: /opt/PoshC2_Project/payloads/dropper_cs.dll
C# Dropper EXE written to: /opt/PoshC2_Project/payloads/dropper_cs.exe
```

10. CBH used wrong param for some paths.

```powershell
PoshC2Path vs PoshC2Dir
```

11. Paths in CBH examples need quotations.

```powershell
Invoke-PoshC2DockerServer -PoshC2Dir "C:\PoshC2" -LocalPoshC2ProjectDir "C:\PoshC2_Project" -DockerPoshC2ProjectDir "/opt/PoshC2_Project"
```

12. Extra -v in `Invoke-PoshC2DockerHandler` breaks it. Removed it.

```powershell
PS C:\Users\justin-p > Invoke-PoshC2DockerHandler -PoshC2Dir "C:\Tools\PoshC2" -LocalPoshC2ProjectDir "C:\PoshC2_Project\" -DockerPoshC2ProjectDir "/opt/PoshC2_Project" -User "root"
C:\ProgramData\chocolatey\lib\docker-cli\tools\docker.exe: invalid reference format: repository name must be lowercase.
See 'C:\ProgramData\chocolatey\lib\docker-cli\tools\docker.exe run --help'.

docker run -ti --rm -v -v $("$LocalPoshC2ProjectDir" + ":" + "$DockerPoshC2ProjectDir") -v $("$PoshC2Dir" + ":" + "/opt/PoshC2") nettitude/poshc2 /usr/bin/posh -u "$User"
                     ^
```
