### PR TITLE
Fix typo backup folder name

### DIFF
--- a/poshc2/server/C2Server.py
+++ b/poshc2/server/C2Server.py
@@ -590,7 +590,7 @@ def main(args):
             if os.path.exists("%spayloads_old" % PoshProjectDirectory):
                 import shutil
                 shutil.rmtree("%spayloads_old" % PoshProjectDirectory)
-            os.rename(PayloadsDirectory, "%sspayloads_old" % PoshProjectDirectory)
+            os.rename(PayloadsDirectory, "%s:_old" % PoshProjectDirectory)
             os.makedirs(PayloadsDirectory)
             C2 = get_c2server_all()
             newPayload = Payloads(C2[5], C2[2], PayloadCommsHost, DomainFrontHeader, C2[8], C2[12],

--- a/poshc2/server/C2Server.py
+++ b/poshc2/server/C2Server.py
@@ -590,7 +590,7 @@ def main(args):
             if os.path.exists("%spayloads_old" % PoshProjectDirectory):
                 import shutil
                 shutil.rmtree("%spayloads_old" % PoshProjectDirectory)
-            os.rename(PayloadsDirectory, "%s:_old" % PoshProjectDirectory)
+            os.rename(PayloadsDirectory, "%sspayloads_old" % PoshProjectDirectory)
             os.makedirs(PayloadsDirectory)
             C2 = get_c2server_all()
             newPayload = Payloads(C2[5], C2[2], PayloadCommsHost, DomainFrontHeader, C2[8], C2[12],

--- a/poshc2/server/C2Server.py
+++ b/poshc2/server/C2Server.py
@@ -590,7 +590,7 @@ def main(args):
             if os.path.exists("%spayloads_old" % PoshProjectDirectory):
                 import shutil
                 shutil.rmtree("%spayloads_old" % PoshProjectDirectory)
-            os.rename(PayloadsDirectory, "%s:_old" % PoshProjectDirectory)
+            os.rename(PayloadsDirectory, "%spayloads_old" % PoshProjectDirectory)
             os.makedirs(PayloadsDirectory)
             C2 = get_c2server_all()
             newPayload = Payloads(C2[5], C2[2], PayloadCommsHost, DomainFrontHeader, C2[8], C2[12],


### PR DESCRIPTION
fix (maybe) typo of backup folder name for payloads which will be created in changing config.
typo is located here https://github.com/er28-0652/PoshC2/blob/master/poshc2/server/C2Server.py#L593

upon running `posh-server` after updating config in second time, it will fail to create backup. (':_old' folder will never be deleted)

![image](https://user-images.githubusercontent.com/33626923/74531511-2f7eec00-4f70-11ea-9a2a-9831ecf7e806.png)

i just fixed typo.
