### PR TITLE
Small change to command_handler for PS Implants

### DIFF
--- a/poshc2/client/command_handlers/PSHandler.py
+++ b/poshc2/client/command_handlers/PSHandler.py
@@ -56,7 +56,7 @@ def handle_ps_command(command, user, randomuri, implant_id):
         do_install_servicelevel_persistencewithproxy(user, command, randomuri)
         return
     elif command.startswith("install-servicelevel-persistence"):
-        do_install_servicelevel_persistencewithproxy(user, command, randomuri)
+        do_install_servicelevel_persistencewith(user, command, randomuri)
         return
     elif command.startswith("remove-servicelevel-persistence"):
         do_remove_servicelevel_persistence(user, command, randomuri)


### PR DESCRIPTION
Currently "install-servicelevel-persistence" and "install-servicelevel-persistencewithproxy" both call do_install_servicelevel_persistencewithproxy(). Modified elif body that checks for "install-servicelevel-persistence" and instead calls do_install_servicelevel_persistencewith() function.

Succesfully tested this modification myself.