### PR TITLE
Mac & Docker Fixes

### DIFF
--- a/Install-for-Docker.sh
+++ b/Install-for-Docker.sh
@@ -101,8 +101,15 @@ chmod +x /usr/local/bin/posh-docker-clean
 chmod +x /usr/local/bin/posh-stop-server
 chmod +x /usr/local/bin/posh-docker-debug
 
-mkdir -p "/var/poshc2"
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/config-template.yml -o "/var/poshc2/config-template.yml" >/dev/null
+
+if [ "$(uname)" == "Darwin" ]; then
+    POSH_PROJECTS_DIR="/private/var/poshc2"
+else
+    POSH_PROJECTS_DIR="/var/poshc2"
+fi
+
+mkdir -p "$POSH_PROJECTS_DIR"
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/config-template.yml -o "$POSH_PROJECTS_DIR/config-template.yml" >/dev/null
 curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/poshc2.service -o /lib/systemd/system/poshc2.service >/dev/null
 
 echo ""

--- a/Install-for-Docker.sh
+++ b/Install-for-Docker.sh
@@ -64,42 +64,42 @@ done
 echo "[+] Installing PoshC2 for Docker"
 echo ""
 echo ""
-echo "[+] Installing scripts to /usr/bin"
-rm -f /usr/bin/_posh-common
-rm -f /usr/bin/fpc
-rm -f /usr/bin/posh
-rm -f /usr/bin/posh-server
-rm -f /usr/bin/posh-config
-rm -f /usr/bin/posh-log
-rm -f /usr/bin/posh-service
-rm -f /usr/bin/posh-stop-service
-rm -f /usr/bin/posh-project
-rm -f /usr/bin/posh-docker-clean
-rm -f /usr/bin/posh-stop-server
-rm -f /usr/bin/posh-docker-debug
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/_posh-common -o /usr/bin/_posh-common >/dev/null
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/fpc -o /usr/bin/fpc >/dev/null
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-docker -o /usr/bin/posh >/dev/null
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-docker-server -o /usr/bin/posh-server >/dev/null
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-config -o /usr/bin/posh-config >/dev/null
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-log -o /usr/bin/posh-log >/dev/null
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-service -o /usr/bin/posh-service >/dev/null
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-stop-service -o /usr/bin/posh-stop-service >/dev/null
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-project -o /usr/bin/posh-project >/dev/null
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-docker-clean -o /usr/bin/posh-docker-clean >/dev/null
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-docker-stop-server -o /usr/bin/posh-stop-server >/dev/null
-curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-docker-debug -o /usr/bin/posh-docker-debug >/dev/null
-chmod +x /usr/bin/fpc
-chmod +x /usr/bin/posh
-chmod +x /usr/bin/posh-server
-chmod +x /usr/bin/posh-config
-chmod +x /usr/bin/posh-log
-chmod +x /usr/bin/posh-service
-chmod +x /usr/bin/posh-stop-service
-chmod +x /usr/bin/posh-project
-chmod +x /usr/bin/posh-docker-clean
-chmod +x /usr/bin/posh-stop-server
-chmod +x /usr/bin/posh-docker-debug
+echo "[+] Installing scripts to /usr/local/bin"
+rm -f /usr/local/bin/_posh-common
+rm -f /usr/local/bin/fpc
+rm -f /usr/local/bin/posh
+rm -f /usr/local/bin/posh-server
+rm -f /usr/local/bin/posh-config
+rm -f /usr/local/bin/posh-log
+rm -f /usr/local/bin/posh-service
+rm -f /usr/local/bin/posh-stop-service
+rm -f /usr/local/bin/posh-project
+rm -f /usr/local/bin/posh-docker-clean
+rm -f /usr/local/bin/posh-stop-server
+rm -f /usr/local/bin/posh-docker-debug
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/_posh-common -o /usr/local/bin/_posh-common >/dev/null
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/fpc -o /usr/local/bin/fpc >/dev/null
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-docker -o /usr/local/bin/posh >/dev/null
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-docker-server -o /usr/local/bin/posh-server >/dev/null
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-config -o /usr/local/bin/posh-config >/dev/null
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-log -o /usr/local/bin/posh-log >/dev/null
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-service -o /usr/local/bin/posh-service >/dev/null
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-stop-service -o /usr/local/bin/posh-stop-service >/dev/null
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-project -o /usr/local/bin/posh-project >/dev/null
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-docker-clean -o /usr/local/bin/posh-docker-clean >/dev/null
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-docker-stop-server -o /usr/local/bin/posh-stop-server >/dev/null
+curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/scripts/posh-docker-debug -o /usr/local/bin/posh-docker-debug >/dev/null
+chmod +x /usr/local/bin/fpc
+chmod +x /usr/local/bin/posh
+chmod +x /usr/local/bin/posh-server
+chmod +x /usr/local/bin/posh-config
+chmod +x /usr/local/bin/posh-log
+chmod +x /usr/local/bin/posh-service
+chmod +x /usr/local/bin/posh-stop-service
+chmod +x /usr/local/bin/posh-project
+chmod +x /usr/local/bin/posh-docker-clean
+chmod +x /usr/local/bin/posh-stop-server
+chmod +x /usr/local/bin/posh-docker-debug
 
 mkdir -p "/var/poshc2"
 curl https://raw.githubusercontent.com/nettitude/PoshC2/$GIT_BRANCH/resources/config-template.yml -o "/var/poshc2/config-template.yml" >/dev/null

--- a/Install-for-Docker.sh
+++ b/Install-for-Docker.sh
@@ -61,7 +61,7 @@ while getopts "h?b:" opt; do
     esac
 done
 
-echo "[+] Installing PoshC2 for Docker"
+echo "[+] Installing PoshC2 for Docker for branch \"$GIT_BRANCH\""
 echo ""
 echo ""
 echo "[+] Installing scripts to /usr/local/bin"

--- a/Install.sh
+++ b/Install.sh
@@ -117,28 +117,28 @@ python3 -m pipenv --three install >/dev/null
 
 echo ""
 echo "[+] Symlinking useful scripts to /usr/bin"
-rm -f /usr/bin/_posh-common
+rm -f /usr/local/bin/_posh-common
 rm -f /usr/bin/fpc
-rm -f /usr/bin/posh
-rm -f /usr/bin/posh-server
-rm -f /usr/bin/posh-config
-rm -f /usr/bin/posh-log
-rm -f /usr/bin/posh-service
-rm -f /usr/bin/posh-stop-service
-rm -f /usr/bin/posh-update
-rm -f /usr/bin/posh-cookie-decryptor
-rm -f /usr/bin/posh-project
-ln -s "$POSH_DIR/resources/scripts/_posh-common" /usr/bin/_posh-common
+rm -f /usr/local/bin/posh
+rm -f /usr/local/bin/posh-server
+rm -f /usr/local/bin/posh-config
+rm -f /usr/local/bin/posh-log
+rm -f /usr/local/bin/posh-service
+rm -f /usr/local/bin/posh-stop-service
+rm -f /usr/local/bin/posh-update
+rm -f /usr/local/bin/posh-cookie-decryptor
+rm -f /usr/local/bin/posh-project
+ln -s "$POSH_DIR/resources/scripts/_posh-common" /usr/local/bin/_posh-common
 ln -s "$POSH_DIR/resources/scripts/fpc" /usr/bin/fpc
-ln -s "$POSH_DIR/resources/scripts/posh" /usr/bin/posh
-ln -s "$POSH_DIR/resources/scripts/posh-server" /usr/bin/posh-server
-ln -s "$POSH_DIR/resources/scripts/posh-config" /usr/bin/posh-config
-ln -s "$POSH_DIR/resources/scripts/posh-log" /usr/bin/posh-log
-ln -s "$POSH_DIR/resources/scripts/posh-service" /usr/bin/posh-service
-ln -s "$POSH_DIR/resources/scripts/posh-stop-service" /usr/bin/posh-stop-service
-ln -s "$POSH_DIR/resources/scripts/posh-update" /usr/bin/posh-update
-ln -s "$POSH_DIR/resources/scripts/posh-cookie-decrypter" /usr/bin/posh-cookie-decryptor
-ln -s "$POSH_DIR/resources/scripts/posh-project" /usr/bin/posh-project
+ln -s "$POSH_DIR/resources/scripts/posh" /usr/local/bin/posh
+ln -s "$POSH_DIR/resources/scripts/posh-server" /usr/local/bin/posh-server
+ln -s "$POSH_DIR/resources/scripts/posh-config" /usr/local/bin/posh-config
+ln -s "$POSH_DIR/resources/scripts/posh-log" /usr/local/bin/posh-log
+ln -s "$POSH_DIR/resources/scripts/posh-service" /usr/local/bin/posh-service
+ln -s "$POSH_DIR/resources/scripts/posh-stop-service" /usr/local/bin/posh-stop-service
+ln -s "$POSH_DIR/resources/scripts/posh-update" /usr/local/bin/posh-update
+ln -s "$POSH_DIR/resources/scripts/posh-cookie-decrypter" /usr/local/bin/posh-cookie-decryptor
+ln -s "$POSH_DIR/resources/scripts/posh-project" /usr/local/bin/posh-project
 chmod +x "$POSH_DIR/resources/scripts/fpc"
 chmod +x "$POSH_DIR/resources/scripts/posh"
 chmod +x "$POSH_DIR/resources/scripts/posh-server"

--- a/Install.sh
+++ b/Install.sh
@@ -118,7 +118,7 @@ python3 -m pipenv --three install >/dev/null
 echo ""
 echo "[+] Symlinking useful scripts to /usr/bin"
 rm -f /usr/local/bin/_posh-common
-rm -f /usr/bin/fpc
+rm -f /usr/local/bin/fpc
 rm -f /usr/local/bin/posh
 rm -f /usr/local/bin/posh-server
 rm -f /usr/local/bin/posh-config
@@ -129,7 +129,7 @@ rm -f /usr/local/bin/posh-update
 rm -f /usr/local/bin/posh-cookie-decryptor
 rm -f /usr/local/bin/posh-project
 ln -s "$POSH_DIR/resources/scripts/_posh-common" /usr/local/bin/_posh-common
-ln -s "$POSH_DIR/resources/scripts/fpc" /usr/bin/fpc
+ln -s "$POSH_DIR/resources/scripts/fpc" /usr/local/bin/fpc
 ln -s "$POSH_DIR/resources/scripts/posh" /usr/local/bin/posh
 ln -s "$POSH_DIR/resources/scripts/posh-server" /usr/local/bin/posh-server
 ln -s "$POSH_DIR/resources/scripts/posh-config" /usr/local/bin/posh-config

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can also run PoshC2 using Docker, this allows more stable and running and en
 
 The Docker install does not clone PoshC2 as the PoshC2 images on Docker Hub are used, so only a minimal install of some dependencies and scripts are performed.
 
-To start with, install Docker on the host and then add the PoshC2 projects directory to Docker as a shared directory if required for your OS. By default this is **/var/poshc2** on *nix.
+To start with, install Docker on the host and then add the PoshC2 projects directory to Docker as a shared directory if required for your OS. By default this is **/var/poshc2** on *nix and **/private/var/poshc2** on Mac.
 
 ### Kali based hosts
 

--- a/poshc2/client/command_handlers/ImplantHandler.py
+++ b/poshc2/client/command_handlers/ImplantHandler.py
@@ -936,6 +936,7 @@ def do_createdaisypayload(user, command):
     newPayload.CreateEXE("%s_" % name)
     newPayload.CreateMsbuild("%s_" % name)
     newPayload.CreateDonutShellcode("%s_" % name)
+    newPayload.BuildDynamicPayloads("%s_" % name)
     print_good("Created new %s daisy payloads" % name)
     input("Press Enter to continue...")
     clear()
@@ -999,6 +1000,7 @@ def do_createnewpayload(user, command, creds=None, shellcodeOnly=False):
         newPayload.CreateMsbuild("%s_" % name)
         newPayload.CreatePython("%s_" % name)
         newPayload.CreateDonutShellcode("%s_" % name)
+        newPayload.BuildDynamicPayloads("%s_" % name)
 
     print_good("Created new payloads")
     input("Press Enter to continue...")

--- a/resources/config-template.yml
+++ b/resources/config-template.yml
@@ -7,7 +7,7 @@ BindIP: '0.0.0.0'
 BindPort: 443
 
 # Database Config
-DatabaseType: SQLite # or Postgres
+DatabaseType: "SQLite" # or Postgres
 PostgresConnectionString: "dbname='poshc2_project_x' port='5432' user='admin' host='192.168.111.111' password='XXXXXXX'" # Only used if Postgres in use
 
 # Payload Comms

--- a/resources/modules/Get-UserLogons.ps1
+++ b/resources/modules/Get-UserLogons.ps1
@@ -1,0 +1,106 @@
+<#
+.Synopsis
+    Gets User Logon Events
+
+    Author: @m0rv4i
+
+.DESCRIPTION
+
+    Lists User Logon Events from an event log and lists them with timestamps and from which hostname.
+
+    Events where the hostname is '-' and machine logon events are excluded.
+
+.PARAMETER Newest
+
+    Check the newest X events. Defaults to 200.
+
+.PARAMETER ComputerName
+
+    Computername to run against using PSRemoting. Defaults to local host.
+
+.PARAMETER ExclusionList
+
+    Account names to exclude. Defaults to "SYSTEM", "NETWORK SERVICE", "DWM-1", "LOCAL SERVICE", "UMFD-0", "UMFD-1".
+
+.PARAMETER ServiceAccounts
+
+    Whether to logic service accounts or not. Defaults to false.
+    Service accounts are accounts starting with SVC_, SVC-, svc_ or svc-.
+
+.EXAMPLE
+
+    PS C:\> Get-UserLogons
+
+    2020-08-17 10:52:40 : BEEROCLOCK\bob -> BEEROCLOCK
+    2020-08-17 10:52:40 : BEEROCLOCK\bob -> BEEROCLOCK
+    2020-08-14 19:00:48 : BEEROCLOCK\bob -> BEEROCLOCK
+    2020-08-14 19:00:48 : BEEROCLOCK\bob -> BEEROCLOCK
+    2020-08-12 21:00:05 : BEEROCLOCK\bob -> BEEROCLOCK
+    2020-08-12 21:00:05 : BEEROCLOCK\bob -> BEEROCLOCK
+
+.EXAMPLE
+
+    PS C:\> Get-UserLogons -Newest 20000 -ServiceAccounts -ComputerName DC01.DOMAIN.LOCAL
+
+.EXAMPLE
+
+    PS C:\> $exclusions = $("SYSTEM", "NETWORK SERVICE", "DWM-1", "LOCAL SERVICE", "UMFD-0", "UMFD-1", "ACCOUNT1", "ACCOUNT2")
+    PS C:\> Get-UserLogons -ServiceAccounts -ComputerName DC01.DOMAIN.LOCAL -ExclusionList $exclusions
+
+#>
+function Get-UserLogons()
+{
+    [CmdletBinding()]
+    Param
+    (
+            [string[]]$ExclusionList = $("SYSTEM", "NETWORK SERVICE", "DWM-1", "LOCAL SERVICE", "UMFD-0", "UMFD-1"),
+            [int]$Newest = 200,
+            [switch]$ServiceAccounts = $false,
+            [string]$ComputerName = ""
+    )
+
+    Write-Output ""
+
+    if($ComputerName)
+    {
+        $LogonEvents = Get-EventLog -newest $Newest -logname security -instanceid 4624 -ComputerName $ComputerName
+    }
+    else
+    {
+        $LogonEvents = Get-EventLog -newest $Newest -logname security -instanceid 4624
+    }
+
+    foreach($Events in $LogonEvents)
+    {
+
+        $LogonUsername = $Events.ReplacementStrings[5]
+        $LogonHostname = $Events.ReplacementStrings[11]
+        $LogonDomain = $Events.ReplacementStrings[6]
+
+        if($ExclusionList -contains $LogonUsername)
+        {
+            continue
+        }
+
+        if($LogonHostname -eq "-")
+        {
+            continue
+        }
+
+        if($LogonUsername.Trim("`$") -eq $LogonHostname)
+        {
+            continue
+        }
+
+        if(!$ServiceAccounts)
+        {
+            if($LogonUsername.ToLower().StartsWith("svc_") -or $LogonUsername.ToLower().StartsWith("svc-"))
+            {
+                continue
+            }
+        }
+
+        Write-Output "$($Events.TimeGenerated.ToString("yyyy-MM-dd HH:mm:ss")) : $LogonDomain\$LogonUsername -> $LogonHostname"
+
+    }
+}

--- a/resources/scripts/PoshC2.psm1
+++ b/resources/scripts/PoshC2.psm1
@@ -121,6 +121,10 @@ Function Start-PoshC2Server {
 
     The Port that the PoshC2 server binds to, defaults to 443.
 
+    .PARAMETER DockerTag
+
+    The tag of the Docker container to use, defaults to 'latest' (master)
+
     .EXAMPLE
 
     Start-PoshC2DockerServer -PoshC2Dir "C:\PoshC2" -LocalPoshC2ProjectDir "C:\PoshC2_Project"
@@ -131,11 +135,12 @@ Function Start-PoshC2Server {
         [string]$PoshC2Dir,
         [Parameter(Mandatory=$true)]
         [string]$LocalPoshC2ProjectDir,
-        [int]$PoshC2Port = 443
+        [int]$PoshC2Port = 443,
+        [string]$DockerTag = "latest"
 
     )
 
-    docker run --rm -p $("$PoshC2Port:$PoshC2Port") -v $("$LocalPoshC2ProjectDir:/var/poshc2") $PoshC2DockerImage /usr/local/bin/posh-server
+    docker run --rm -p $("$PoshC2Port:$PoshC2Port") -v $("$LocalPoshC2ProjectDir:/var/poshc2") $PoshC2DockerImage:$DockerTag /usr/local/bin/posh-server
 }
 
 Function Start-PoshC2DockerHandler {
@@ -163,8 +168,12 @@ Function Start-PoshC2DockerHandler {
 
     .PARAMETER User
 
-    The user to login as in the ImplantHandler.x
+    The user to login as in the ImplantHandler.
 
+    .PARAMETER DockerTag
+
+    The tag of the Docker container to use, defaults to 'latest' (master)
+    
     .EXAMPLE
 
     Start-PoshC2DockerHandler -PoshC2Dir "C:\PoshC2" -PoshC2ProjectDir "C:\PoshC2_Project" -User CrashOverride
@@ -175,10 +184,11 @@ Function Start-PoshC2DockerHandler {
         [string]$PoshC2Dir,
         [Parameter(Mandatory=$true)]
         [string]$LocalPoshC2ProjectDir,
-        [string]$User = ""
+        [string]$User = "",
+        [string]$DockerTag = "latest"
     )
 
-    docker run -ti --rm -v $("$LocalPoshC2ProjectDir:/var/poshc2") $PoshC2DockerImage /usr/local/bin/posh -u "$User"
+    docker run -ti --rm -v $("$LocalPoshC2ProjectDir:/var/poshc2") $PoshC2DockerImage:$DockerTag /usr/local/bin/posh -u "$User"
 }
 
 Export-ModuleMember -Function Build-PoshC2DockerImage -Alias posh-docker-build

--- a/resources/scripts/PoshC2.psm1
+++ b/resources/scripts/PoshC2.psm1
@@ -135,7 +135,7 @@ Function Start-PoshC2Server {
 
     )
 
-    docker run --rm -p $("$PoshC2Port:$PoshC2Port") -v $("$LocalPoshC2ProjectDir:/var/poshc2") $PoshC2DockerImage /usr/bin/posh-server
+    docker run --rm -p $("$PoshC2Port:$PoshC2Port") -v $("$LocalPoshC2ProjectDir:/var/poshc2") $PoshC2DockerImage /usr/local/bin/posh-server
 }
 
 Function Start-PoshC2DockerHandler {
@@ -178,7 +178,7 @@ Function Start-PoshC2DockerHandler {
         [string]$User = ""
     )
 
-    docker run -ti --rm -v $("$LocalPoshC2ProjectDir:/var/poshc2") $PoshC2DockerImage /usr/bin/posh -u "$User"
+    docker run -ti --rm -v $("$LocalPoshC2ProjectDir:/var/poshc2") $PoshC2DockerImage /usr/local/bin/posh -u "$User"
 }
 
 Export-ModuleMember -Function Build-PoshC2DockerImage -Alias posh-docker-build

--- a/resources/scripts/_posh-common
+++ b/resources/scripts/_posh-common
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 get_posh_projects_dir(){
-    POSH_PROJECTS_DIR="/var/poshc2"
+    if [ "$(uname)" == "Darwin" ]; then
+        POSH_PROJECTS_DIR="/private/var/poshc2"
+    else
+        POSH_PROJECTS_DIR="/var/poshc2"
+    fi
 }
 
 get_docker_posh_projects_dir(){

--- a/resources/scripts/fpc
+++ b/resources/scripts/fpc
@@ -8,7 +8,7 @@ function ctrl_c() {
     exit
 }
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_dir
 get_posh_project_dir
 

--- a/resources/scripts/posh
+++ b/resources/scripts/posh
@@ -8,7 +8,7 @@ function ctrl_c() {
     exit
 }
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_dir
 
 pushd "$POSH_DIR" >/dev/null

--- a/resources/scripts/posh-config
+++ b/resources/scripts/posh-config
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_project_dir
 
 if [[ "$EDITOR" != "" ]]; then

--- a/resources/scripts/posh-cookie-decrypter
+++ b/resources/scripts/posh-cookie-decrypter
@@ -8,7 +8,7 @@ function ctrl_c() {
     exit
 }
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_dir
 
 pushd $POSH_DIR  >/dev/null

--- a/resources/scripts/posh-docker
+++ b/resources/scripts/posh-docker
@@ -10,10 +10,10 @@ show_help(){
     echo "Usage:"
     echo "posh -t <docker-image-tag> -u <username>"
     echo ""
-    echo "Default Docker tag is master"
+    echo "Default Docker tag is latest (master)"
 }
 
-DOCKER_TAG="master"
+DOCKER_TAG="latest"
 USER=""
 
 while getopts "h?t:u:" opt; do

--- a/resources/scripts/posh-docker
+++ b/resources/scripts/posh-docker
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_projects_dir
 get_docker_posh_projects_dir
 get_docker_image_name
@@ -30,7 +30,7 @@ while getopts "h?t:u:" opt; do
 done
 
 if [ ! -z "$USER" ]; then
-    sudo -E docker run -ti -l posh-client --rm -v "$POSH_PROJECTS_DIR:$DOCKER_POSH_PROJECTS_DIR" "$DOCKER_IMAGE_NAME":"$DOCKER_TAG" /usr/bin/posh -u "$USER"
+    sudo -E docker run -ti -l posh-client --rm -v "$POSH_PROJECTS_DIR:$DOCKER_POSH_PROJECTS_DIR" "$DOCKER_IMAGE_NAME":"$DOCKER_TAG" /usr/local/bin/posh -u "$USER"
 else
-    sudo -E docker run -ti -l posh-client --rm -v "$POSH_PROJECTS_DIR:$DOCKER_POSH_PROJECTS_DIR" "$DOCKER_IMAGE_NAME":"$DOCKER_TAG" /usr/bin/posh
+    sudo -E docker run -ti -l posh-client --rm -v "$POSH_PROJECTS_DIR:$DOCKER_POSH_PROJECTS_DIR" "$DOCKER_IMAGE_NAME":"$DOCKER_TAG" /usr/local/bin/posh
 fi

--- a/resources/scripts/posh-docker-build
+++ b/resources/scripts/posh-docker-build
@@ -8,7 +8,7 @@ function ctrl_c() {
     exit
 }
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_dir
 get_docker_image_name
 

--- a/resources/scripts/posh-docker-debug
+++ b/resources/scripts/posh-docker-debug
@@ -10,10 +10,10 @@ show_help(){
     echo "Usage:"
     echo "posh-docker-debug -t <docker-image-tag>"
     echo ""
-    echo "Default Docker tag is master"
+    echo "Default Docker tag is latest (master)"
 }
 
-DOCKER_TAG="master"
+DOCKER_TAG="latest"
 
 while getopts "h?t:" opt; do
     case "$opt" in

--- a/resources/scripts/posh-docker-debug
+++ b/resources/scripts/posh-docker-debug
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_projects_dir
 get_docker_posh_projects_dir
 get_docker_image_name

--- a/resources/scripts/posh-docker-server
+++ b/resources/scripts/posh-docker-server
@@ -13,10 +13,10 @@ show_help(){
     echo "Usage:"
     echo "posh-server -t <docker-image-tag>"
     echo ""
-    echo "Default is master"
+    echo "Default Docker tag is latest (master)"
 }
 
-DOCKER_TAG="master"
+DOCKER_TAG="latest"
 
 while getopts "h?t:" opt; do
     case "$opt" in

--- a/resources/scripts/posh-docker-server
+++ b/resources/scripts/posh-docker-server
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_project_dir
 get_posh_projects_dir
 get_docker_posh_projects_dir
@@ -29,5 +29,5 @@ while getopts "h?t:" opt; do
     esac
 done
 
-sudo -E docker run --rm -l posh-server -p "$POSHC2_PORT:$POSHC2_PORT" -v "$POSH_PROJECTS_DIR:$DOCKER_POSH_PROJECTS_DIR" "$DOCKER_IMAGE_NAME":"$DOCKER_TAG" /usr/bin/posh-server
+sudo -E docker run --rm -l posh-server -p "$POSHC2_PORT:$POSHC2_PORT" -v "$POSH_PROJECTS_DIR:$DOCKER_POSH_PROJECTS_DIR" "$DOCKER_IMAGE_NAME":"$DOCKER_TAG" /usr/local/bin/posh-server
 

--- a/resources/scripts/posh-docker-stop-server
+++ b/resources/scripts/posh-docker-stop-server
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_docker_image_name
 
 echo "[*] Stopping the PoshC2 server Docker container..."

--- a/resources/scripts/posh-log
+++ b/resources/scripts/posh-log
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_project_dir
 
 tail -n 5000 -f "$POSH_PROJECT_DIR/poshc2_server.log" 2>/dev/null\

--- a/resources/scripts/posh-project
+++ b/resources/scripts/posh-project
@@ -51,7 +51,7 @@ elif [ "$1" == "-l" ]; then
     fi
 
     echo "[*] Listing PoshC2 Projects in $POSH_PROJECTS_DIR"
-    command ls -dl /var/poshc2/*/ 2>/dev/null | cut -d '/' -f 4
+    command ls -dl $POSH_PROJECTS_DIR/*/ 2>/dev/null | cut -d '/' -f 4
 
 elif [ "$1" == "-c" ]; then
 

--- a/resources/scripts/posh-project
+++ b/resources/scripts/posh-project
@@ -8,7 +8,7 @@ function ctrl_c() {
     exit
 }
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_projects_dir
 
 if [ "$1" == "-n" ]; then

--- a/resources/scripts/posh-server
+++ b/resources/scripts/posh-server
@@ -8,7 +8,7 @@ function ctrl_c() {
     exit
 }
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_dir
 get_posh_project_dir
 

--- a/resources/scripts/posh-service
+++ b/resources/scripts/posh-service
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_project_dir
 
 sudo systemctl enable poshc2.service >/dev/null
@@ -12,5 +12,5 @@ while [[ $x -le 10 ]]; do
     sleep 1s
     x=$(( $x + 1 ))
 done
-/usr/bin/posh-log
+/usr/local/bin/posh-log
 

--- a/resources/scripts/posh-update
+++ b/resources/scripts/posh-update
@@ -33,7 +33,7 @@ while getopts "h?b:" opt; do
     esac
 done
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_dir
 
 pushd $POSH_DIR  >/dev/null

--- a/resources/scripts/poshc2.service
+++ b/resources/scripts/poshc2.service
@@ -4,7 +4,7 @@ Description=PoshC2 Server
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/bin/posh-server
+ExecStart=/usr/local/bin/posh-server
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
* On Mac you can't share `/var/poshc2` as it forces it to `/private/var/poshc2`, so automatically account for this.
* Macs don't let you install to `/usr/bin` but allow to `/usr/local/bin`. As this is a valid path for Linux, change all install paths to this directory.
* Docker replaces the 'master' tag with 'latest', but keeps all other branches and tags the same so in the docker scripts replace references to master with latest. (Note this may not necessarily be the latest branch but it's a Docker thing)