### PR TITLE
Fixed executable path in ansible script

### DIFF
--- a/resources/scripts/posh-service-ansible
+++ b/resources/scripts/posh-service-ansible
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /usr/bin/_posh-common
+source /usr/local/bin/_posh-common
 get_posh_project_dir
 
 sudo systemctl enable poshc2.service >/dev/null


### PR DESCRIPTION
The current posh-service-ansible script sources the wrong path, which this PR is intended to fix. 