### PR TITLE
Remove blank line in urls.txt

### DIFF
--- a/resources/urls.txt
+++ b/resources/urls.txt
@@ -30,4 +30,3 @@ http://127.0.0.1/webhp?hl=en&sa=X&ved=
 http://127.0.0.1/work/embedded/search?oid=
 http://127.0.0.1/GoPro5/black/2018/
 http://127.0.0.1/Philips/v902/
-


### PR DESCRIPTION
Kirk and KTT mentioned this in MM breaking initial setup, trimmed empty line at end of resources/URLs.txt