### PR TITLE
Scripting improvements

### DIFF
--- a/Install-for-Docker.sh
+++ b/Install-for-Docker.sh
@@ -140,3 +140,9 @@ echo "Other options:"
 echo "posh-service <-- This will run the C2 server as a service instead of in the foreground"
 echo "posh-stop-service <-- This will stop the service"
 echo "posh-log <-- This will view the C2 log if the server is already running"
+echo "Add the following to your .bashrc or .zshrc to be able to quickly switch to the PoshC2 project directory using posh-dir"
+echo "
+function posh-dir(){
+    cd `posh-project -g`
+}
+"

--- a/Install.sh
+++ b/Install.sh
@@ -198,3 +198,10 @@ echo "Other options:"
 echo "posh-service <-- This will run the C2 server as a service instead of in the foreground"
 echo "posh-stop-service <-- This will stop the service"
 echo "posh-log <-- This will view the C2 log if the server is already running"
+echo ""
+echo "Add the following to your .bashrc or .zshrc to be able to quickly switch to the PoshC2 project directory using posh-dir"
+echo "
+function posh-dir(){
+    cd `posh-project -g`
+}
+"

--- a/resources/scripts/posh-project
+++ b/resources/scripts/posh-project
@@ -50,8 +50,16 @@ elif [ "$1" == "-l" ]; then
         exit 1
     fi
 
+    current_project=`cat $POSH_PROJECTS_DIR/CURRENT_PROJECT`
     echo "[*] Listing PoshC2 Projects in $POSH_PROJECTS_DIR"
-    command ls -dl $POSH_PROJECTS_DIR/*/ 2>/dev/null | cut -d '/' -f 4
+    projects=`command ls -dl $POSH_PROJECTS_DIR/*/ 2>/dev/null | cut -d '/' -f 4`
+    for project in $projects; do
+        if [ "$project" == "$current_project" ]; then
+            echo "$project*"
+        else
+            echo "$project"
+        fi
+    done
 
 elif [ "$1" == "-c" ]; then
 
@@ -62,6 +70,16 @@ elif [ "$1" == "-c" ]; then
 
     echo "[*] Current project: "
     cat "$POSH_PROJECTS_DIR/CURRENT_PROJECT"
+
+elif [ "$1" == "-g" ]; then
+
+    if [ ! -f "$POSH_PROJECTS_DIR/CURRENT_PROJECT" ]; then
+        echo "[-] No current project selected."
+        exit 1
+    fi
+
+    current_project=`cat $POSH_PROJECTS_DIR/CURRENT_PROJECT`
+    echo "$POSH_PROJECTS_DIR/$current_project"
 
 elif [ "$1" == "-d" ]; then
 
@@ -84,4 +102,5 @@ else
     echo "[*] Usage: posh-project -l (lists projects)"
     echo "[*] Usage: posh-project -d <project-to-delete>"
     echo "[*] Usage: posh-project -c (shows current project)"
+    echo "[*] Usage: posh-project -g (quietly shows current project directory for scripting)"
 fi


### PR DESCRIPTION
* `posh-project -l` now highlights which project is in use with an asterisk:
```
# posh-project -l                                                                                                                                                                                                                                                                                
[*] Listing PoshC2 Projects in /var/poshc2
daisytest2
domaincheck*
runas
safety
timeouts2
```
* `posh-project -g` will quietly print the full path to the project directory (useful for scripting):
```
# posh-project -g
/var/poshc2/domaincheck
```

* For example, the *install scripts* now suggest adding the following to the bottom of your .zshrc or .bashrc file so you can use `posh-dir` to automatically `cd` to the current posh project directory:

```
# tail ~/.zshrc                                                                                                                                                                                                                                                                        

function posh-dir(){
    cd `posh-project -g`
}

# posh-dir                                                                                                                                                                                                                                                                                       
drwxrwxrwx    - root  3 Nov 15:41 .
drwxr-xr-x    - root  3 Nov 14:16 ..
drwxrwxrwx    - root  3 Nov 15:00 downloads
drwxrwxrwx    - root  3 Nov 15:01 payloads
drwxrwxrwx    - root  3 Nov 15:00 reports
.rwxrwxrwx   80 root  3 Nov 15:39 .implant-history
.rwxrwxrwx   35 root  3 Nov 15:39 .top-history
.rwxrwxrwx 1.6k root  3 Nov 14:26 config.yml
.rwxrwxrwx 1.2k root  3 Nov 15:01 posh.crt
.rwxrwxrwx 1.7k root  3 Nov 15:01 posh.key
.rwxrwxrwx  18k root  3 Nov 15:41 poshc2_server.log
.rwxrwxrwx 106k root  3 Nov 15:41 PowershellC2.SQLite
.rwxrwxrwx 9.3k root  3 Nov 15:01 quickstart.txt
.rwxrwxrwx 3.2k root  3 Nov 15:00 rewrite-rules.txt
.rwxrwxrwx 201k root  3 Nov 15:42 webserver.log
```

(You have to add this to the shell init file as a function as scripts run in their own process, so changing directory has no affect on the actual current shell).
