### PR TITLE
Update config-template.yml

### DIFF
--- a/resources/config-template.yml
+++ b/resources/config-template.yml
@@ -20,7 +20,7 @@ UserAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
 DefaultSleep: "5s"
 Jitter: 0.20
 KillDate: "2999-12-01"  # yyyy-MM-dd
-UrlConfig: "urls" # Beacon URLs will be taken from resources/urls.txt if value is 'urls'. If value is 'wordlists' beacon URLs will be randomly generated on server creation from resources/wordlist.txt
+UrlConfig: "urls" # Beacon URLs will be taken from resources/urls.txt if value is 'urls'. If value is 'wordlist' beacon URLs will be randomly generated on server creation from resources/wordlist.txt
 
 # Payload Options
 PayloadStageRetries: true


### PR DESCRIPTION
Help text in the config says 'wordlists' but actually the config expects 'wordlist' and errors if you supply 'wordlists' upon starting posh-server

Coming in with the BIG CRITICAL ISSUES these days :eyes:

@m0rv4i 