### PR TITLE
Updating Credits

### DIFF
--- a/resources/payload-templates/Implant-Core.js
+++ b/resources/payload-templates/Implant-Core.js
@@ -1,3 +1,4 @@
+// Pulled from https://github.com/its-a-feature/Mythic/blob/master/Payload_Types/apfell/agent_code/base/apfell-jxa.js#L2-L7
 ObjC.import('Cocoa');
 ObjC.import('Foundation');
 ObjC.import('stdlib');
@@ -39,6 +40,7 @@ var sleepTime = "5";
 var newSleep = "%s";
 sleepTime = beacon(newSleep);
 
+// pulled from https://github.com/its-a-feature/Mythic/blob/master/Payload_Types/apfell/agent_code/base/apfell-jxa.js#L9-L30
 // Implant Information (Used to show what user, hostname, IP, etc)
 class agent{
 	constructor(){
@@ -94,6 +96,7 @@ function writeFile(file, data) {
     return "File written";
 };
 
+// pulled from https://github.com/its-a-feature/Mythic/blob/master/Payload_Types/apfell/agent_code/shell.js#L2-L23
 function run_shell(command){
 	//simply run a shell command via doShellScript and return the response
     let response = "";
@@ -152,7 +155,7 @@ function enc(data){
     //console.log(final_message.base64EncodedStringWithOptions(0).js);
     return final_message.base64EncodedStringWithOptions(0).js;
 }
-
+// pulled from https://github.com/its-a-feature/Mythic/blob/master/Payload_Types/apfell/agent_code/c2_profiles/HTTP.js#L115-L132
 function dec(nsdata){
     //takes in a base64 encoded string to be decrypted and returned
     let err = Ref();
@@ -171,7 +174,7 @@ function dec(nsdata){
     let decrypted_message = $.NSString.alloc.initWithDataEncoding(decryptedData, $.NSUTF8StringEncoding);
     return decrypted_message;
 }
-
+// pulled from https://github.com/its-a-feature/Mythic/blob/master/Payload_Types/apfell/agent_code/base/apfell-jxa.js#L106-L115
 function decode(data) {
     // base64 decoding
 	if(typeof data == "string"){
@@ -183,7 +186,7 @@ function decode(data) {
 	var decoded_data = $.NSString.alloc.initWithDataEncoding(ns_data, $.NSUTF8StringEncoding).js;
 	return decoded_data;
 }
-
+// pulled from https://github.com/its-a-feature/Mythic/blob/master/Payload_Types/apfell/agent_code/base/apfell-jxa.js#L116-L124
 function encode(data) {
     //base64 encoding
 	if(typeof data == "string"){
@@ -195,7 +198,7 @@ function encode(data) {
 	var encstring = ns_data.base64EncodedStringWithOptions(0).js;
 	return encstring;
 }
-
+// pulled from https://github.com/its-a-feature/Mythic/blob/master/Payload_Types/apfell/agent_code/base/apfell-jxa.js#L70-L74
 convert_to_nsdata = function(strData){
     // helper function to convert UTF8 strings to NSData objects
     var tmpString = $.NSString.alloc.initWithCStringEncoding(strData, $.NSData.NSUnicodeStringEncoding);

--- a/resources/payload-templates/Implant-Core.js
+++ b/resources/payload-templates/Implant-Core.js
@@ -123,7 +123,8 @@ function run_jxa(m){
     return cmdOutput;
 };
 
-// partly based on Apfel https://github.com/its-a-feature/Mythic
+// partly based on Apfell https://github.com/its-a-feature/Mythic
+// pulled fromhttps://github.com/its-a-feature/Mythic/blob/14b06e3755cea0f291ea6246fc315b9b30388640/Payload_Types/apfell/agent_code/c2_profiles/HTTP.js#L82-L113
 function enc(data){
     // takes in the string we're about to send, encrypts it, and returns a new string
     let err = Ref();


### PR DESCRIPTION
Good morning!

I saw that you added a new JXA agent, which is awesome! I also noticed some... similarities to my JXA agent (Apfell) in the Mythic project. I noticed that there was a git commit to "update credits" (https://github.com/nettitude/PoshC2/commit/6e57ba04ce631ca0e299448228cd6d07aa0118b0#diff-d44483fae061144fc048885de857d2fecf371eab75ea1f66709f1449cedd60dd). However, that just calls out one function as "partially based on" (same with the blog post announcing that my agent was inspiration for the encryption function). I wanted to go ahead and open a pull request and highlight that it is actually more than just inspiration for one function - my code and comments are all over the place. So, hopefully this can help bring to light the amount of... inspiration that was used :)

Also, when my code made its way into your agent, I think you accidentally took out too much or didn't quite understand why some things were they way that they were. For example:
in the `run_shell` command (https://github.com/nettitude/PoshC2/blob/master/resources/payload-templates/Implant-Core.js#L97-L115) when you tried to strip out the way I passed in the command to run (https://github.com/its-a-feature/Mythic/blob/master/Payload_Types/apfell/agent_code/shell.js#L7-L11) but leave everything else there (including my comments), you missed _why_ there's that modification for the `&` at the end. Since you took it out, you can't actually properly background shell commands. I call it out in the comments, but go ahead and give this a try:

```
osascript -l JavaScript -i
let app = Application.currentApplication()
app.includeStandardAdditions = true;
app.doShellScript("sleep 5")
app.doShellScript("sleep 5 &")
app.doShellScript("sleep 5 &>/dev/null &")
```
