### PR TITLE
Python YAML Module Missing - Fix

### DIFF
--- a/Install.sh
+++ b/Install.sh
@@ -115,6 +115,7 @@ python3 -m pip install --upgrade pip > /dev/null
 python3 -m pip install pandas pipenv > /dev/null
 cd "$POSH_DIR"
 python3 -m pipenv --three install >/dev/null
+python3 -m pipenv install pyyaml #Needed to fix bug were yaml moduel not included in python env causing posh-server command to crash.
 cd resources/SharpSocks/
 unzip -o SharpSocksServer.zip
 chmod +x SharpSocksServer/SharpSocksServer


### PR DESCRIPTION
Found an issue when install Posh using the one line cURL command on clean install of Kali 2022.4 (other methods and versions may be effected) where the Python  yaml module was not available to the posh scripts meaning the server cannot launch. Added one line (118) to explicitly install pyyaml inside the Python env. This resolved the issue for me and my team.